### PR TITLE
Add CI workflow and consolidate validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,66 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: Validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.24'
+        cache: true
+
+    - name: Download dependencies
+      run: go mod download
+
+    - name: Verify dependencies
+      run: go mod verify
+
+    - name: Install golangci-lint
+      uses: golangci/golangci-lint-action@v8
+      with:
+        version: v2.1
+
+    - name: Run validation (same as local)
+      run: |
+        if ! make validate; then
+          echo '::error title=Validation Failed::make validate failed'
+          exit 1
+        fi
+
+    - name: Run tests with coverage
+      run: |
+        if ! go test -v -race -coverprofile=coverage.txt -covermode=atomic ./...; then
+          echo '::error title=Test Failures::Tests with coverage failed'
+          exit 1
+        fi
+        echo '✅ Tests with coverage passed'
+
+    - name: Build
+      run: |
+        if ! go build -v ./...; then
+          echo '::error title=Build Failed::Build failed'
+          exit 1
+        fi
+        echo '✅ Build successful'

--- a/Makefile
+++ b/Makefile
@@ -24,18 +24,33 @@ tools: ## Install development tools
 	go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
 
 .PHONY: validate
-validate: ## Run all validation checks (format, vet, test, lint)
+validate: ## Run all validation checks (same as CI)
 	@echo "Running validation checks..."
-	@echo "1. Formatting..."
-	@go fmt ./...
-	@echo "2. Vetting..."
+	@echo "1. Checking formatting..."
+	@if [ -n "$$(gofmt -l .)" ]; then \
+		echo "❌ Code is not formatted. Run 'go fmt ./...'"; \
+		gofmt -d .; \
+		exit 1; \
+	fi
+	@echo "✅ Code formatting OK"
+	@echo "2. Running go vet..."
 	@go vet ./...
-	@echo "3. Testing..."
-	@go test ./...
-	@echo "4. Tidying modules..."
+	@echo "✅ go vet OK"
+	@echo "3. Running tests with race detector..."
+	@go test -race -shuffle=on ./...
+	@echo "✅ Tests OK"
+	@echo "4. Checking go.mod..."
 	@go mod tidy
-	@echo "5. Linting..."
-	@golangci-lint run ./...
+	@if [ -n "$$(git status --porcelain go.mod go.sum)" ]; then \
+		echo "❌ go.mod/go.sum need updating. Run 'go mod tidy'"; \
+		git diff go.mod go.sum; \
+		exit 1; \
+	fi
+	@echo "✅ go.mod OK"
+	@echo "5. Running linter..."
+	@golangci-lint run --timeout=5m ./...
+	@echo "✅ Linting OK"
+	@echo ""
 	@echo "✅ All validation checks passed!"
 
 .PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ validate: ## Run all validation checks (same as CI)
 	@echo "4. Checking go.mod..."
 	@go mod tidy
 	@if [ -n "$$(git status --porcelain go.mod go.sum)" ]; then \
-		echo "❌ go.mod/go.sum need updating. Run 'go mod tidy'"; \
+		echo "❌ go.mod/go.sum needs updating. Run 'go mod tidy'"; \
 		git diff go.mod go.sum; \
 		exit 1; \
 	fi

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # bookid
 
-![CI](https://github.com/fwojciec/bookid/workflows/CI/badge.svg)
+![CI workflow status](https://github.com/fwojciec/bookid/workflows/CI/badge.svg)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # bookid
+
+![CI](https://github.com/fwojciec/bookid/workflows/CI/badge.svg)


### PR DESCRIPTION
## Summary
- Add GitHub Actions CI workflow that runs on push/PR to main
- Consolidate `make validate` to work the same locally and in CI
- Add CI status badge to README

## Details
The CI workflow enforces our coding standards as the "last line of defense":
- ✅ Code formatting (gofmt)
- ✅ Static analysis (go vet)
- ✅ Tests with race detector
- ✅ Module tidiness (go mod tidy)
- ✅ Linting (golangci-lint)

The workflow configuration matches the bookscanner project:
- Uses same action versions (checkout@v4, setup-go@v5, golangci-lint@v8)
- Proper Go caching configured
- Concurrency control to cancel redundant runs
- 10-minute timeout
- Clear error annotations in GitHub UI

## Test Plan
- [x] Run `make validate` locally - all checks pass
- [ ] CI should run automatically when this PR is created
- [ ] CI should pass all checks

🤖 Generated with [Claude Code](https://claude.ai/code)