### PR TITLE
Add bookid CLI utility and fix thumbnail URLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,4 +42,5 @@ ehthumbs.db
 Thumbs.db
 
 # Project binaries
-bookid
+/bookid
+/cmd/bookid/bookid

--- a/cmd/bookid/main.go
+++ b/cmd/bookid/main.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/fwojciec/bookid"
+	"github.com/fwojciec/bookid/googlebooks"
+)
+
+const (
+	defaultTimeout = 30 * time.Second
+)
+
+type Config struct {
+	GoogleBooksAPIKey string
+	Timeout           time.Duration
+}
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	if len(os.Args) < 2 {
+		return fmt.Errorf("usage: bookid <search query>")
+	}
+
+	// Combine all arguments after the program name as the search query
+	query := strings.Join(os.Args[1:], " ")
+
+	// Load configuration
+	config := loadConfig()
+
+	// Create Google Books client
+	client, err := googlebooks.NewClient(config.GoogleBooksAPIKey)
+	if err != nil {
+		return fmt.Errorf("creating Google Books client: %w", err)
+	}
+
+	// Create context with timeout
+	ctx, cancel := context.WithTimeout(context.Background(), config.Timeout)
+	defer cancel()
+
+	// Perform search
+	results, err := client.Search(ctx, query)
+	if err != nil {
+		return fmt.Errorf("searching for books: %w", err)
+	}
+
+	// Return just the top result if any results were found
+	if len(results) == 0 {
+		// Return empty response
+		response := struct {
+			Query  string             `json:"query"`
+			Result *bookid.BookResult `json:"result"`
+		}{
+			Query:  query,
+			Result: nil,
+		}
+		encoder := json.NewEncoder(os.Stdout)
+		encoder.SetIndent("", "  ")
+		encoder.SetEscapeHTML(false)
+		return encoder.Encode(response)
+	}
+
+	// Get the top result and strip out the raw Google Books data
+	topResult := results[0]
+	topResult.GoogleBooksData = nil
+
+	response := struct {
+		Query  string            `json:"query"`
+		Result bookid.BookResult `json:"result"`
+	}{
+		Query:  query,
+		Result: topResult,
+	}
+
+	// Output as pretty-printed JSON without HTML escaping
+	encoder := json.NewEncoder(os.Stdout)
+	encoder.SetIndent("", "  ")
+	encoder.SetEscapeHTML(false)
+	if err := encoder.Encode(response); err != nil {
+		return fmt.Errorf("encoding JSON output: %w", err)
+	}
+
+	return nil
+}
+
+func loadConfig() Config {
+	config := Config{
+		GoogleBooksAPIKey: os.Getenv("GOOGLE_BOOKS_API_KEY"),
+		Timeout:           defaultTimeout,
+	}
+
+	// Allow timeout override via environment variable
+	if timeoutStr := os.Getenv("BOOKID_TIMEOUT"); timeoutStr != "" {
+		if timeout, err := time.ParseDuration(timeoutStr); err == nil {
+			config.Timeout = timeout
+		}
+	}
+
+	return config
+}

--- a/googlebooks/client.go
+++ b/googlebooks/client.go
@@ -127,9 +127,9 @@ func volumeToBookResult(volume *books.Volume, searchType bookid.SearchType, dete
 	// Extract thumbnail URL and ensure HTTPS
 	if volume.VolumeInfo.ImageLinks != nil {
 		if volume.VolumeInfo.ImageLinks.Thumbnail != "" {
-			result.ThumbnailURL = strings.Replace(volume.VolumeInfo.ImageLinks.Thumbnail, "http://", "https://", 1)
+			result.ThumbnailURL = ensureHTTPS(volume.VolumeInfo.ImageLinks.Thumbnail)
 		} else if volume.VolumeInfo.ImageLinks.SmallThumbnail != "" {
-			result.ThumbnailURL = strings.Replace(volume.VolumeInfo.ImageLinks.SmallThumbnail, "http://", "https://", 1)
+			result.ThumbnailURL = ensureHTTPS(volume.VolumeInfo.ImageLinks.SmallThumbnail)
 		}
 	}
 
@@ -200,4 +200,13 @@ func extractYear(dateStr string) int {
 	}
 
 	return 0
+}
+
+// ensureHTTPS converts HTTP URLs to HTTPS
+func ensureHTTPS(url string) string {
+	if url == "" {
+		return ""
+	}
+	// Use ReplaceAll for robustness, even though current API only has http:// at the beginning
+	return strings.ReplaceAll(url, "http://", "https://")
 }

--- a/googlebooks/client.go
+++ b/googlebooks/client.go
@@ -124,12 +124,12 @@ func volumeToBookResult(volume *books.Volume, searchType bookid.SearchType, dete
 		result.PublishedYear = year
 	}
 
-	// Extract thumbnail URL
+	// Extract thumbnail URL and ensure HTTPS
 	if volume.VolumeInfo.ImageLinks != nil {
 		if volume.VolumeInfo.ImageLinks.Thumbnail != "" {
-			result.ThumbnailURL = volume.VolumeInfo.ImageLinks.Thumbnail
+			result.ThumbnailURL = strings.Replace(volume.VolumeInfo.ImageLinks.Thumbnail, "http://", "https://", 1)
 		} else if volume.VolumeInfo.ImageLinks.SmallThumbnail != "" {
-			result.ThumbnailURL = volume.VolumeInfo.ImageLinks.SmallThumbnail
+			result.ThumbnailURL = strings.Replace(volume.VolumeInfo.ImageLinks.SmallThumbnail, "http://", "https://", 1)
 		}
 	}
 

--- a/googlebooks/testdata/isbn_9780743273565.json
+++ b/googlebooks/testdata/isbn_9780743273565.json
@@ -10,7 +10,7 @@
     "published_year": 2004,
     "language": "en",
     "google_books_volume_id": "fIlQDwAAQBAJ",
-    "thumbnail_url": "http://books.google.com/books/content?id=fIlQDwAAQBAJ\u0026printsec=frontcover\u0026img=1\u0026zoom=1\u0026edge=curl\u0026source=gbs_api",
+    "thumbnail_url": "https://books.google.com/books/content?id=fIlQDwAAQBAJ\u0026printsec=frontcover\u0026img=1\u0026zoom=1\u0026edge=curl\u0026source=gbs_api",
     "google_books_data": {
       "accessInfo": {
         "accessViewStatus": "SAMPLE",
@@ -22,7 +22,7 @@
         "viewability": "PARTIAL",
         "webReaderLink": "http://play.google.com/books/reader?id=fIlQDwAAQBAJ\u0026hl=\u0026source=gbs_api"
       },
-      "etag": "OzE3kMJod54",
+      "etag": "Aq71xuM9PO0",
       "id": "fIlQDwAAQBAJ",
       "kind": "books#volume",
       "saleInfo": {

--- a/googlebooks/testdata/title_author_gatsby.json
+++ b/googlebooks/testdata/title_author_gatsby.json
@@ -10,7 +10,7 @@
     "published_year": 2013,
     "language": "en",
     "google_books_volume_id": "2vwoHo3MMpwC",
-    "thumbnail_url": "http://books.google.com/books/content?id=2vwoHo3MMpwC\u0026printsec=frontcover\u0026img=1\u0026zoom=1\u0026edge=curl\u0026source=gbs_api",
+    "thumbnail_url": "https://books.google.com/books/content?id=2vwoHo3MMpwC\u0026printsec=frontcover\u0026img=1\u0026zoom=1\u0026edge=curl\u0026source=gbs_api",
     "google_books_data": {
       "accessInfo": {
         "accessViewStatus": "SAMPLE",
@@ -25,7 +25,7 @@
         "viewability": "PARTIAL",
         "webReaderLink": "http://play.google.com/books/reader?id=2vwoHo3MMpwC\u0026hl=\u0026source=gbs_api"
       },
-      "etag": "d0ipfiqW7D4",
+      "etag": "HZIYqNEQIA4",
       "id": "2vwoHo3MMpwC",
       "kind": "books#volume",
       "saleInfo": {
@@ -90,7 +90,7 @@
     "published_year": 2020,
     "language": "en",
     "google_books_volume_id": "gnQJEAAAQBAJ",
-    "thumbnail_url": "http://books.google.com/books/content?id=gnQJEAAAQBAJ\u0026printsec=frontcover\u0026img=1\u0026zoom=1\u0026edge=curl\u0026source=gbs_api",
+    "thumbnail_url": "https://books.google.com/books/content?id=gnQJEAAAQBAJ\u0026printsec=frontcover\u0026img=1\u0026zoom=1\u0026edge=curl\u0026source=gbs_api",
     "google_books_data": {
       "accessInfo": {
         "accessViewStatus": "SAMPLE",
@@ -102,7 +102,7 @@
         "viewability": "PARTIAL",
         "webReaderLink": "http://play.google.com/books/reader?id=gnQJEAAAQBAJ\u0026hl=\u0026source=gbs_api"
       },
-      "etag": "Dfc+esARsEg",
+      "etag": "XaeLiBu74D8",
       "id": "gnQJEAAAQBAJ",
       "kind": "books#volume",
       "saleInfo": {
@@ -163,7 +163,7 @@
     "published_year": 2015,
     "language": "en",
     "google_books_volume_id": "WpD_DAAAQBAJ",
-    "thumbnail_url": "http://books.google.com/books/content?id=WpD_DAAAQBAJ\u0026printsec=frontcover\u0026img=1\u0026zoom=1\u0026edge=curl\u0026source=gbs_api",
+    "thumbnail_url": "https://books.google.com/books/content?id=WpD_DAAAQBAJ\u0026printsec=frontcover\u0026img=1\u0026zoom=1\u0026edge=curl\u0026source=gbs_api",
     "google_books_data": {
       "accessInfo": {
         "accessViewStatus": "SAMPLE",
@@ -181,7 +181,7 @@
         "viewability": "PARTIAL",
         "webReaderLink": "http://play.google.com/books/reader?id=WpD_DAAAQBAJ\u0026hl=\u0026source=gbs_api"
       },
-      "etag": "urx2Yj6Po0o",
+      "etag": "+ameaYWFpWs",
       "id": "WpD_DAAAQBAJ",
       "kind": "books#volume",
       "saleInfo": {
@@ -238,7 +238,7 @@
     "published_year": 2020,
     "language": "en",
     "google_books_volume_id": "xmnuDwAAQBAJ",
-    "thumbnail_url": "http://books.google.com/books/content?id=xmnuDwAAQBAJ\u0026printsec=frontcover\u0026img=1\u0026zoom=1\u0026edge=curl\u0026source=gbs_api",
+    "thumbnail_url": "https://books.google.com/books/content?id=xmnuDwAAQBAJ\u0026printsec=frontcover\u0026img=1\u0026zoom=1\u0026edge=curl\u0026source=gbs_api",
     "google_books_data": {
       "accessInfo": {
         "accessViewStatus": "SAMPLE",
@@ -250,7 +250,7 @@
         "viewability": "PARTIAL",
         "webReaderLink": "http://play.google.com/books/reader?id=xmnuDwAAQBAJ\u0026hl=\u0026source=gbs_api"
       },
-      "etag": "e2MA812Y1KM",
+      "etag": "jlKH3mi0DS4",
       "id": "xmnuDwAAQBAJ",
       "kind": "books#volume",
       "saleInfo": {
@@ -313,7 +313,7 @@
     "published_year": 2000,
     "language": "en",
     "google_books_volume_id": "qYiMEAAAQBAJ",
-    "thumbnail_url": "http://books.google.com/books/content?id=qYiMEAAAQBAJ\u0026printsec=frontcover\u0026img=1\u0026zoom=1\u0026source=gbs_api",
+    "thumbnail_url": "https://books.google.com/books/content?id=qYiMEAAAQBAJ\u0026printsec=frontcover\u0026img=1\u0026zoom=1\u0026source=gbs_api",
     "google_books_data": {
       "accessInfo": {
         "accessViewStatus": "NONE",
@@ -324,7 +324,7 @@
         "viewability": "NO_PAGES",
         "webReaderLink": "http://play.google.com/books/reader?id=qYiMEAAAQBAJ\u0026hl=\u0026source=gbs_api"
       },
-      "etag": "NoupLVWLdFA",
+      "etag": "TuuypxDF/0g",
       "id": "qYiMEAAAQBAJ",
       "kind": "books#volume",
       "saleInfo": {
@@ -396,7 +396,7 @@
         "viewability": "NO_PAGES",
         "webReaderLink": "http://play.google.com/books/reader?id=cnqszwEACAAJ\u0026hl=\u0026source=gbs_api"
       },
-      "etag": "NzuMtR7eLEo",
+      "etag": "0yvAEGjV09A",
       "id": "cnqszwEACAAJ",
       "kind": "books#volume",
       "saleInfo": {
@@ -448,7 +448,7 @@
     "published_year": 2021,
     "language": "en",
     "google_books_volume_id": "1b9zzgEACAAJ",
-    "thumbnail_url": "http://books.google.com/books/content?id=1b9zzgEACAAJ\u0026printsec=frontcover\u0026img=1\u0026zoom=1\u0026source=gbs_api",
+    "thumbnail_url": "https://books.google.com/books/content?id=1b9zzgEACAAJ\u0026printsec=frontcover\u0026img=1\u0026zoom=1\u0026source=gbs_api",
     "google_books_data": {
       "accessInfo": {
         "accessViewStatus": "NONE",
@@ -459,7 +459,7 @@
         "viewability": "NO_PAGES",
         "webReaderLink": "http://play.google.com/books/reader?id=1b9zzgEACAAJ\u0026hl=\u0026source=gbs_api"
       },
-      "etag": "5Rr0Gjs+LZA",
+      "etag": "FeB6RlEVL4w",
       "id": "1b9zzgEACAAJ",
       "kind": "books#volume",
       "saleInfo": {
@@ -513,7 +513,7 @@
     "published_year": 2019,
     "language": "en",
     "google_books_volume_id": "InrADwAAQBAJ",
-    "thumbnail_url": "http://books.google.com/books/content?id=InrADwAAQBAJ\u0026printsec=frontcover\u0026img=1\u0026zoom=1\u0026edge=curl\u0026source=gbs_api",
+    "thumbnail_url": "https://books.google.com/books/content?id=InrADwAAQBAJ\u0026printsec=frontcover\u0026img=1\u0026zoom=1\u0026edge=curl\u0026source=gbs_api",
     "google_books_data": {
       "accessInfo": {
         "accessViewStatus": "SAMPLE",
@@ -531,7 +531,7 @@
         "viewability": "PARTIAL",
         "webReaderLink": "http://play.google.com/books/reader?id=InrADwAAQBAJ\u0026hl=\u0026source=gbs_api"
       },
-      "etag": "E0VM3WVYWAU",
+      "etag": "ZBtj38zz8vk",
       "id": "InrADwAAQBAJ",
       "kind": "books#volume",
       "saleInfo": {
@@ -595,7 +595,7 @@
     "published_year": 2024,
     "language": "en",
     "google_books_volume_id": "tbgCEQAAQBAJ",
-    "thumbnail_url": "http://books.google.com/books/content?id=tbgCEQAAQBAJ\u0026printsec=frontcover\u0026img=1\u0026zoom=1\u0026source=gbs_api",
+    "thumbnail_url": "https://books.google.com/books/content?id=tbgCEQAAQBAJ\u0026printsec=frontcover\u0026img=1\u0026zoom=1\u0026source=gbs_api",
     "google_books_data": {
       "accessInfo": {
         "accessViewStatus": "NONE",
@@ -606,7 +606,7 @@
         "viewability": "NO_PAGES",
         "webReaderLink": "http://play.google.com/books/reader?id=tbgCEQAAQBAJ\u0026hl=\u0026source=gbs_api"
       },
-      "etag": "m/CWCuxqm74",
+      "etag": "4PzWn1Z0LNA",
       "id": "tbgCEQAAQBAJ",
       "kind": "books#volume",
       "saleInfo": {
@@ -665,7 +665,7 @@
     "published_year": 2021,
     "language": "en",
     "google_books_volume_id": "c-PbDwAAQBAJ",
-    "thumbnail_url": "http://books.google.com/books/content?id=c-PbDwAAQBAJ\u0026printsec=frontcover\u0026img=1\u0026zoom=1\u0026edge=curl\u0026source=gbs_api",
+    "thumbnail_url": "https://books.google.com/books/content?id=c-PbDwAAQBAJ\u0026printsec=frontcover\u0026img=1\u0026zoom=1\u0026edge=curl\u0026source=gbs_api",
     "google_books_data": {
       "accessInfo": {
         "accessViewStatus": "SAMPLE",
@@ -677,7 +677,7 @@
         "viewability": "PARTIAL",
         "webReaderLink": "http://play.google.com/books/reader?id=c-PbDwAAQBAJ\u0026hl=\u0026source=gbs_api"
       },
-      "etag": "FVnlhB4c/5U",
+      "etag": "7HlvkEIPqtE",
       "id": "c-PbDwAAQBAJ",
       "kind": "books#volume",
       "saleInfo": {

--- a/googlebooks/testdata/title_only_pride.json
+++ b/googlebooks/testdata/title_only_pride.json
@@ -10,7 +10,7 @@
     "published_year": 2001,
     "language": "en",
     "google_books_volume_id": "mxDLY0qL2mAC",
-    "thumbnail_url": "http://books.google.com/books/content?id=mxDLY0qL2mAC\u0026printsec=frontcover\u0026img=1\u0026zoom=1\u0026edge=curl\u0026source=gbs_api",
+    "thumbnail_url": "https://books.google.com/books/content?id=mxDLY0qL2mAC\u0026printsec=frontcover\u0026img=1\u0026zoom=1\u0026edge=curl\u0026source=gbs_api",
     "google_books_data": {
       "accessInfo": {
         "accessViewStatus": "SAMPLE",
@@ -28,7 +28,7 @@
         "viewability": "PARTIAL",
         "webReaderLink": "http://play.google.com/books/reader?id=mxDLY0qL2mAC\u0026hl=\u0026source=gbs_api"
       },
-      "etag": "jw2t+8YkQSQ",
+      "etag": "E223GaFEK4Q",
       "id": "mxDLY0qL2mAC",
       "kind": "books#volume",
       "saleInfo": {
@@ -93,7 +93,7 @@
     "published_year": 1980,
     "language": "en",
     "google_books_volume_id": "EvqJCGeqKhsC",
-    "thumbnail_url": "http://books.google.com/books/content?id=EvqJCGeqKhsC\u0026printsec=frontcover\u0026img=1\u0026zoom=1\u0026source=gbs_api",
+    "thumbnail_url": "https://books.google.com/books/content?id=EvqJCGeqKhsC\u0026printsec=frontcover\u0026img=1\u0026zoom=1\u0026source=gbs_api",
     "google_books_data": {
       "accessInfo": {
         "accessViewStatus": "NONE",
@@ -104,7 +104,7 @@
         "viewability": "NO_PAGES",
         "webReaderLink": "http://play.google.com/books/reader?id=EvqJCGeqKhsC\u0026hl=\u0026source=gbs_api"
       },
-      "etag": "nNTPFvM0ymM",
+      "etag": "JpiZ0P9Fsq0",
       "id": "EvqJCGeqKhsC",
       "kind": "books#volume",
       "saleInfo": {
@@ -175,7 +175,7 @@
         "viewability": "NO_PAGES",
         "webReaderLink": "http://play.google.com/books/reader?id=QuoSDAEACAAJ\u0026hl=\u0026source=gbs_api"
       },
-      "etag": "MMaLRXWGaE4",
+      "etag": "lFbG4V6/r+Q",
       "id": "QuoSDAEACAAJ",
       "kind": "books#volume",
       "saleInfo": {
@@ -229,7 +229,7 @@
     "published_year": 2016,
     "language": "en",
     "google_books_volume_id": "3UQLvgAACAAJ",
-    "thumbnail_url": "http://books.google.com/books/content?id=3UQLvgAACAAJ\u0026printsec=frontcover\u0026img=1\u0026zoom=1\u0026source=gbs_api",
+    "thumbnail_url": "https://books.google.com/books/content?id=3UQLvgAACAAJ\u0026printsec=frontcover\u0026img=1\u0026zoom=1\u0026source=gbs_api",
     "google_books_data": {
       "accessInfo": {
         "accessViewStatus": "NONE",
@@ -240,7 +240,7 @@
         "viewability": "NO_PAGES",
         "webReaderLink": "http://play.google.com/books/reader?id=3UQLvgAACAAJ\u0026hl=\u0026source=gbs_api"
       },
-      "etag": "YEVACjlJ0Vk",
+      "etag": "yKxiQsJ0R8w",
       "id": "3UQLvgAACAAJ",
       "kind": "books#volume",
       "saleInfo": {
@@ -298,7 +298,7 @@
     "published_year": 2000,
     "language": "en",
     "google_books_volume_id": "mTQ46Xt_mkMC",
-    "thumbnail_url": "http://books.google.com/books/content?id=mTQ46Xt_mkMC\u0026printsec=frontcover\u0026img=1\u0026zoom=1\u0026edge=curl\u0026source=gbs_api",
+    "thumbnail_url": "https://books.google.com/books/content?id=mTQ46Xt_mkMC\u0026printsec=frontcover\u0026img=1\u0026zoom=1\u0026edge=curl\u0026source=gbs_api",
     "google_books_data": {
       "accessInfo": {
         "accessViewStatus": "SAMPLE",
@@ -313,7 +313,7 @@
         "viewability": "PARTIAL",
         "webReaderLink": "http://play.google.com/books/reader?id=mTQ46Xt_mkMC\u0026hl=\u0026source=gbs_api"
       },
-      "etag": "Gmqs0S31BPU",
+      "etag": "cTLRlp92Gwg",
       "id": "mTQ46Xt_mkMC",
       "kind": "books#volume",
       "saleInfo": {
@@ -377,7 +377,7 @@
     "published_year": 2019,
     "language": "en",
     "google_books_volume_id": "fgmGDwAAQBAJ",
-    "thumbnail_url": "http://books.google.com/books/content?id=fgmGDwAAQBAJ\u0026printsec=frontcover\u0026img=1\u0026zoom=1\u0026edge=curl\u0026source=gbs_api",
+    "thumbnail_url": "https://books.google.com/books/content?id=fgmGDwAAQBAJ\u0026printsec=frontcover\u0026img=1\u0026zoom=1\u0026edge=curl\u0026source=gbs_api",
     "google_books_data": {
       "accessInfo": {
         "accessViewStatus": "SAMPLE",
@@ -392,7 +392,7 @@
         "viewability": "PARTIAL",
         "webReaderLink": "http://play.google.com/books/reader?id=fgmGDwAAQBAJ\u0026hl=\u0026source=gbs_api"
       },
-      "etag": "HuN1ecWCpdw",
+      "etag": "ENn0r9DmwCc",
       "id": "fgmGDwAAQBAJ",
       "kind": "books#volume",
       "saleInfo": {
@@ -456,7 +456,7 @@
     "published_year": 2024,
     "language": "en",
     "google_books_volume_id": "-4cWEQAAQBAJ",
-    "thumbnail_url": "http://books.google.com/books/content?id=-4cWEQAAQBAJ\u0026printsec=frontcover\u0026img=1\u0026zoom=1\u0026edge=curl\u0026source=gbs_api",
+    "thumbnail_url": "https://books.google.com/books/content?id=-4cWEQAAQBAJ\u0026printsec=frontcover\u0026img=1\u0026zoom=1\u0026edge=curl\u0026source=gbs_api",
     "google_books_data": {
       "accessInfo": {
         "accessViewStatus": "SAMPLE",
@@ -474,7 +474,7 @@
         "viewability": "PARTIAL",
         "webReaderLink": "http://play.google.com/books/reader?id=-4cWEQAAQBAJ\u0026hl=\u0026source=gbs_api"
       },
-      "etag": "XoQfv2NFntU",
+      "etag": "1SdoZcwmVW0",
       "id": "-4cWEQAAQBAJ",
       "kind": "books#volume",
       "saleInfo": {
@@ -564,7 +564,7 @@
     "published_year": 2011,
     "language": "id",
     "google_books_volume_id": "0GFQAwAAQBAJ",
-    "thumbnail_url": "http://books.google.com/books/content?id=0GFQAwAAQBAJ\u0026printsec=frontcover\u0026img=1\u0026zoom=1\u0026edge=curl\u0026source=gbs_api",
+    "thumbnail_url": "https://books.google.com/books/content?id=0GFQAwAAQBAJ\u0026printsec=frontcover\u0026img=1\u0026zoom=1\u0026edge=curl\u0026source=gbs_api",
     "google_books_data": {
       "accessInfo": {
         "accessViewStatus": "SAMPLE",
@@ -579,7 +579,7 @@
         "viewability": "PARTIAL",
         "webReaderLink": "http://play.google.com/books/reader?id=0GFQAwAAQBAJ\u0026hl=\u0026source=gbs_api"
       },
-      "etag": "AGtsmPu5AX8",
+      "etag": "GLeQ329rsD4",
       "id": "0GFQAwAAQBAJ",
       "kind": "books#volume",
       "saleInfo": {
@@ -666,7 +666,7 @@
     "published_year": 2020,
     "language": "en",
     "google_books_volume_id": "umIJzgEACAAJ",
-    "thumbnail_url": "http://books.google.com/books/content?id=umIJzgEACAAJ\u0026printsec=frontcover\u0026img=1\u0026zoom=1\u0026source=gbs_api",
+    "thumbnail_url": "https://books.google.com/books/content?id=umIJzgEACAAJ\u0026printsec=frontcover\u0026img=1\u0026zoom=1\u0026source=gbs_api",
     "google_books_data": {
       "accessInfo": {
         "accessViewStatus": "NONE",
@@ -677,7 +677,7 @@
         "viewability": "NO_PAGES",
         "webReaderLink": "http://play.google.com/books/reader?id=umIJzgEACAAJ\u0026hl=\u0026source=gbs_api"
       },
-      "etag": "4j13+/Sk9Kk",
+      "etag": "WlcfO3iP+p4",
       "id": "umIJzgEACAAJ",
       "kind": "books#volume",
       "saleInfo": {
@@ -740,7 +740,7 @@
         "viewability": "NO_PAGES",
         "webReaderLink": "http://play.google.com/books/reader?id=w9WtjwEACAAJ\u0026hl=\u0026source=gbs_api"
       },
-      "etag": "mF8q82ICn30",
+      "etag": "Ug94IbUlecQ",
       "id": "w9WtjwEACAAJ",
       "kind": "books#volume",
       "saleInfo": {


### PR DESCRIPTION
## Summary
- Added a CLI utility at `cmd/bookid/main.go` that wraps the BookFinder interface
- Fixed Google Books thumbnail URLs to use HTTPS and proper JSON encoding
- Updated golden test files with HTTPS URLs

## Changes
1. **New CLI utility** (`cmd/bookid/main.go`):
   - Takes all command-line arguments as a search query
   - Returns only the top result in clean JSON format
   - Supports `GOOGLE_BOOKS_API_KEY` and `BOOKID_TIMEOUT` environment variables
   - Disables HTML escaping for proper URL formatting

2. **Google Books client improvements**:
   - Convert HTTP thumbnail URLs to HTTPS for better compatibility
   - Updated all golden test files with real API responses using HTTPS

3. **Updated .gitignore**:
   - Made binary exclusions more specific to allow source files in cmd/

## Usage Example
```bash
# Search by title
bookid "The Great Gatsby" | jq .

# Search by ISBN
bookid "978-0-7432-7356-5" | jq .

# Extract specific fields
bookid "golang programming" | jq .result.title
```

## Test plan
- [x] Run `make validate` - all checks pass
- [x] Test CLI with various queries
- [x] Verify thumbnail URLs work with HTTPS
- [x] Golden files updated and tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)